### PR TITLE
Add Nix

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -79,6 +79,10 @@ files = [ '%.jl$' ]
 remote = 'https://github.com/MunifTanjim/tree-sitter-lua'
 files = [ '%.lua$' ]
 
+[nix]
+remote = 'https://github.com/nix-community/tree-sitter-nix'
+files = [ '%.nix$']
+
 [rust]
 remote = 'https://github.com/tree-sitter/tree-sitter-rust'
 files = [ '%.rs$' ]

--- a/lock.json
+++ b/lock.json
@@ -205,6 +205,18 @@
                 }
             }
         },
+        "nix": {
+            "commit": "eabf96807ea4ab6d6c7f09b671a88cd483542840",
+            "files": {
+                "incs": {
+                    "src/tree_sitter/parser.h": "8e819abdeba5866bf1aaf6e7b97522241c903d94a18395c6a75ed02984270ee8"
+                },
+                "srcs": {
+                    "src/parser.c": "2b1d7945441b83e324cd225663481d35e51cd9ae84189cc7e69f58a11ecb85ad",
+                    "src/scanner.c": "45e12521e8be62ea47525417c64d9372fa34e9e12bff643c430b8b3607be9d56"
+                }
+            }
+        },
         "rust": {
             "commit": "261b20226c04ef601adbdf185a800512a5f66291",
             "files": {

--- a/manifest.json
+++ b/manifest.json
@@ -509,6 +509,42 @@
             ]
         },
         {
+            "id": "evergreen_nix",
+            "version": "0",
+            "mod_version": "3",
+            "type": "plugin",
+            "dependencies": {
+                "evergreen": {}
+            },
+            "files": [
+                {
+                    "arch": "aarch64-darwin",
+                    "url": "https://github.com/Evergreen-lxl/evergreen-languages/releases/download/aarch64-darwin/evergreen_nix-aarch64-darwin.zip",
+                    "checksum": "5a7fac6591e66a30eaf079b2e11895b1045f1f95e7a4f163073c71ff76f3cc6b"
+                },
+                {
+                    "arch": "aarch64-linux",
+                    "url": "https://github.com/Evergreen-lxl/evergreen-languages/releases/download/aarch64-linux/evergreen_nix-aarch64-linux.zip",
+                    "checksum": "33656a1aaae6163fc6d305ec1cc089291e1c6ea06701b5e2694ca604730aaa15"
+                },
+                {
+                    "arch": "x86_64-darwin",
+                    "url": "https://github.com/Evergreen-lxl/evergreen-languages/releases/download/x86_64-darwin/evergreen_nix-x86_64-darwin.zip",
+                    "checksum": "3d788bdb0498cbe5311f4e260730485669ad7018b30272e733867b1b26efb8d5"
+                },
+                {
+                    "arch": "x86_64-linux",
+                    "url": "https://github.com/Evergreen-lxl/evergreen-languages/releases/download/x86_64-linux/evergreen_nix-x86_64-linux.zip",
+                    "checksum": "851c66b7934eca1ae01f47bd20f733cd10d5415b1e8dd0f695ed47775a895f64"
+                },
+                {
+                    "arch": "x86_64-windows",
+                    "url": "https://github.com/Evergreen-lxl/evergreen-languages/releases/download/x86_64-windows/evergreen_nix-x86_64-windows.zip",
+                    "checksum": "922906b7f1b592ddc5ced52928f2911d7dbeca007a8015da72b0a1d424e4ad02"
+                }
+            ]
+        },
+        {
             "id": "evergreen_rust",
             "version": "18",
             "mod_version": "3",


### PR DESCRIPTION
It seems to build fine but I am encountering a lot of crashes depending on the file opened.

I get a `double free or corruption (!prev)` or `malloc(): invalid next size (unsorted)` when opening [flake.nix](https://github.com/PassiveLemon/lemonix/blob/master/flake.nix). This file crashes Lite-XL every single time.

Files in [hosts](https://github.com/PassiveLemon/lemonix/tree/master/hosts) sometimes crash Lite-XL with the same errors, but I cannot find a pattern as to why it crashes.

Not sure if this is an issue in Lite-XL, Evergreen, or the Nix TS grammer but I figured this is probably the best place to report it

Fixes #3 